### PR TITLE
Switch to using confuse

### DIFF
--- a/beetsplug/ibroadcast/__init__.py
+++ b/beetsplug/ibroadcast/__init__.py
@@ -4,7 +4,7 @@
 import os
 
 from beets.plugins import BeetsPlugin
-from beets.util.confit import ConfigSource, load_yaml
+from confuse import ConfigSource, load_yaml
 
 from beetsplug.ibroadcast.command import IBroadcastCommand
 

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     install_requires=[
         'beets>=1.4.9',
         'ibroadcast>=1.1.1',
+        'confuse',
     ],
 
     tests_require=[


### PR DESCRIPTION
This commit fixed a warning:
```
beets/util/confit.py:21: UserWarning: beets.util.confit is deprecated; use confuse instead
  warnings.warn("beets.util.confit is deprecated; use confuse instead")
```