### PR TITLE
Manage invalid tagids and resolve conflicts

### DIFF
--- a/beetsplug/ibroadcast/command.py
+++ b/beetsplug/ibroadcast/command.py
@@ -269,7 +269,7 @@ class IBroadcastCommand(Subcommand):
             self.tags[tagname] = {'id': tagid}
             return tagid
         except Exception as e:
-            self.plugin._log.error(f"Error creating iBroadcast tag 'tagname'.")
+            self.plugin._log.error(f"Error creating iBroadcast tag '{tagname}'.")
             self._stack_trace(e)
 
     def _local_tagids(self, item):

--- a/beetsplug/ibroadcast/command.py
+++ b/beetsplug/ibroadcast/command.py
@@ -251,7 +251,7 @@ class IBroadcastCommand(Subcommand):
         self._update_tags(item, lastsync_tagids)
 
     def _tagname(self, tagid):
-        return self.ib.tags[tagid]['name']
+        return self.ib.tags[tagid]['name'] if tagid in self.ib.tags else None
 
     def _tagid(self, tagname):
         if tagname in self.tags:

--- a/beetsplug/ibroadcast/command.py
+++ b/beetsplug/ibroadcast/command.py
@@ -232,7 +232,7 @@ class IBroadcastCommand(Subcommand):
                 self._stack_trace(e)
 
         for tagid in locally_removed:
-            self.plugin._log.debug(f"--> Removing remote tag '{self._tagname(tagid)}' [{tagid}]")
+            self.plugin._log.debug(f"--> Removing remote tag '{self._tagname(tagid) or '[deleted tag]'}' [{tagid}]")
             try:
                 self.ib.tagtracks(tagid, [trackid], untag=True)
                 lastsync_tagids.remove(tagid)
@@ -245,7 +245,7 @@ class IBroadcastCommand(Subcommand):
             lastsync_tagids.add(tagid)
 
         for tagid in remotely_removed:
-            self.plugin._log.debug(f"--> Removing local tag '{self._tagname(tagid)}' [{tagid}]")
+            self.plugin._log.debug(f"--> Removing local tag '{self._tagname(tagid) or '[deleted tag]'}' [{tagid}]")
             if tagid in lastsync_tagids: 
                 # If the tag was removed both locally AND remotely,
                 # then the id was already removed from the set.

--- a/beetsplug/ibroadcast/command.py
+++ b/beetsplug/ibroadcast/command.py
@@ -246,7 +246,10 @@ class IBroadcastCommand(Subcommand):
 
         for tagid in remotely_removed:
             self.plugin._log.debug(f"--> Removing local tag '{self._tagname(tagid)}' [{tagid}]")
-            lastsync_tagids.remove(tagid)
+            if tagid in lastsync_tagids: 
+                # If the tag was removed both locally AND remotely,
+                # then the id was already removed from the set.
+                lastsync_tagids.remove(tagid)
 
         self._update_tags(item, lastsync_tagids)
 


### PR DESCRIPTION
Fixes #7. Syncing after removing a tag from a track both locally and remotely will log both. If it involved the tag being deleted from iBroadcast, then the tag name will be displayed as "[deleted tag]", as there is no way of knowing what the actual name was. Comes with a safety check because that means that it's not longer in iBroadcast's list of tags.

Also includes a small change in eec96ba where I noticed an error message that was clearly supposed to be formatted, but it wasn't. Just a couple missing curly brackets!